### PR TITLE
Added Chunked Send Wrapper

### DIFF
--- a/src/leo_net.erl
+++ b/src/leo_net.erl
@@ -1,0 +1,62 @@
+%%======================================================================
+%%
+%% Leo Commons
+%%
+%% Copyright (c) 2012-2015 Rakuten, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+%% Leo Commons - Network (Util)
+%%
+%% @doc leo_net is utilities for network transport
+%% @reference https://github.com/leo-project/leo_commons/blob/master/src/leo_net.erl
+%% @end
+%%======================================================================
+-module(leo_net).
+
+-author('Wilson Li').
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DEF_SENDING_CHUNK_SIZE,    131072).
+
+-export([chunked_send/3, chunked_send/4]).
+-spec(chunked_send(Transport, Socket, IOList) ->
+                    ok | {error, any()} when Transport::module(),
+                                             Socket::inet:socket(),
+                                             IOList::iodata()).
+chunked_send(Transport, Socket, IOData) ->
+    chunked_send(Transport, Socket, IOData, ?DEF_SENDING_CHUNK_SIZE).
+
+-spec(chunked_send(Transport, Socket, IOList, ChunkSize) ->
+                    ok | {error, any()} when Transport::module(),
+                                             Socket::inet:socket(),
+                                             IOList::iodata(),
+                                             ChunkSize::pos_integer()).
+
+chunked_send(Transport, Socket, IOList, ChunkSize) when is_list(IOList) ->
+    Bin = iolist_to_binary(IOList),
+    chunked_send(Transport, Socket, Bin, ChunkSize);
+chunked_send(Transport, Socket, Bin, ChunkSize) when byte_size(Bin) =< ChunkSize ->
+    Transport:send(Socket, Bin);
+chunked_send(Transport, Socket, Bin, ChunkSize) ->
+    <<Head:ChunkSize/binary, Rest/binary>> = Bin,
+    case Transport:send(Socket, Head) of
+        ok ->
+            chunked_send(Transport, Socket, Rest, ChunkSize);
+        {error, Cause} ->
+            {error, Cause}
+    end.

--- a/test/leo_net_tests.erl
+++ b/test/leo_net_tests.erl
@@ -1,0 +1,72 @@
+%%====================================================================
+%%
+%% Leo Commons
+%%
+%% Copyright (c) 2012-2014 Rakuten, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%% Network Util Test
+%% @doc
+%% @end
+%%====================================================================
+-module(leo_net_tests).
+-author('Wilson Li').
+
+-include("leo_commons.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([client/2,
+         client/3]).
+-define(TEST_SIZE,  1048576).
+
+%%--------------------------------------------------------------------
+%% TEST
+%%--------------------------------------------------------------------
+-ifdef(EUNIT).
+client(Port, Bin) ->
+    {ok, Socket} = gen_tcp:connect("localhost", Port, [binary, {packet, 0}]),
+    leo_net:chunked_send(gen_tcp, Socket, Bin).
+
+client(Port, Bin, ChunkSize) ->
+    {ok, Socket} = gen_tcp:connect("localhost", Port, [binary, {packet, 0}]),
+    leo_net:chunked_send(gen_tcp, Socket, Bin, ChunkSize).
+
+chunked_send_test() ->
+    ?debugMsg("===== Testing chunked_send ====="),
+    Bin = crypto:rand_bytes(?TEST_SIZE),
+
+    {ok, LSocket} = gen_tcp:listen(0, [binary, {packet, 0},
+                                       {active, false}]),
+    {ok, Port} = inet:port(LSocket),
+
+    ?debugMsg("===== Testing chunked_send (default) ====="),
+    spawn_link(?MODULE, client, [Port, Bin]), 
+    {ok, CSocket} = gen_tcp:accept(LSocket),
+    {ok, Bin} = gen_tcp:recv(CSocket, ?TEST_SIZE),
+    
+    ?debugMsg("===== Testing chunked_send (1 byte) ====="),
+    spawn_link(?MODULE, client, [Port, Bin, 1]), 
+    {ok, CSocket2} = gen_tcp:accept(LSocket),
+    {ok, Bin} = gen_tcp:recv(CSocket2, ?TEST_SIZE),
+
+    ?debugMsg("===== Testing chunked_send (4 MB) ====="),
+    spawn_link(?MODULE, client, [Port, Bin, 4194304]), 
+    {ok, CSocket3} = gen_tcp:accept(LSocket),
+    {ok, Bin} = gen_tcp:recv(CSocket3, ?TEST_SIZE),
+    ok.
+
+-endif.


### PR DESCRIPTION
### Description
Added a wrapper to break down network transfer to fixed size chunks.
One of the purposes for this is to allow easy configuration for lower bound of transfer speed which is
```
Lower Bound Rate = Send Chunk Size / Socket Timeout

Default = 128KB / 30s (~4KBps)
```

### Related Issue
https://github.com/leo-project/leofs/issues/429