### PR TITLE
Add mime type 'application/vnd.android.package-archive'

### DIFF
--- a/src/leo_mime.erl
+++ b/src/leo_mime.erl
@@ -429,5 +429,7 @@ from_extension(".woff") ->
     <<"application/x-font-woff">>;
 from_extension(".otf") ->
     <<"font/opentype">>;
+from_extension(".apk") ->
+    <<"application/vnd.android.package-archive">>;
 from_extension(_) ->
     undefined.


### PR DESCRIPTION
This add support for Android APK mime type mentioned in #497

Tested with with curl and reports correct mime type now.

Test output:
```
 HTTP/1.1 200 OK
 transfer-encoding: identity
 date: Thu, 20 Oct 2016 06:25:15 GMT
 connection: close
 server: LeoFS
 Content-Type: application/vnd.android.package-archive
 ETag: "8ff13be4316c6e104169d1fa7226969e"
 Content-Length: 22264514
 Last-Modified: Thu, 20 Oct 2016 06:25:07 GMT
```