### PR TITLE
Correct mime types for .webm & .webp

### DIFF
--- a/src/leo_mime.erl
+++ b/src/leo_mime.erl
@@ -419,9 +419,9 @@ from_extension(".ttf") ->
 from_extension(".vcf") ->
     <<"text/x-vcard">>;
 from_extension(".webm") ->
-    <<"video/web">>;
+    <<"video/webm">>;
 from_extension(".webp") ->
-    <<"image/web">>;
+    <<"image/webp">>;
 from_extension(".woff") ->
     <<"application/x-font-woff">>;
 from_extension(".otf") ->


### PR DESCRIPTION
Correcting mime types for .webm & .webp reference leofs issue [#1019](https://github.com/leo-project/leofs/issues/1019)